### PR TITLE
Add some renderers

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,7 +1,20 @@
 import React from "react";
 import { Redirect, Route, Switch, Link } from "react-router-dom";
 
+import { InteractiveExample } from "./ingredients/interactive-example";
+import { Attributes } from "./ingredients/attributes";
+import { Examples } from "./ingredients/examples";
+
 const LOCALES = ["en-US"];
+
+// Eventually these should be available directly from the documentJSON
+const HEADINGS = {
+    'short-description': 'Short description',
+    'overview': 'Overview',
+    'usage-notes': 'Usage notes',
+    'accessibility-concerns': 'Accessibility concerns',
+    'see-also': 'See also'
+}
 
 function App(appProps) {
   return (
@@ -160,77 +173,53 @@ class Document extends React.Component {
   }
 }
 
+const renderers = {
+   'interactive-example': InteractiveExample,
+   'attributes': Attributes,
+   'examples': Examples,
+//   'browser-compatibility': BrowserCompatibility
+}
+
+function RenderIngredient(ingredientFullName, documentJSON) {
+    // one of the ingredients is not a string, and we don't handle it yet
+    if (typeof ingredientFullName !== "string") {
+        return '';
+    }
+    let parts = ingredientFullName.split('.');
+    if (parts.length !== 2) {
+        throw new Error(
+            `ingredient name '${ingredientFullName}' should be 2 strings separated by a period`
+        );
+    }
+
+    let ingredientType = parts[0];
+    let ingredientName = parts[1];
+    // we're not checking for missing mandatory sections here (yet?)
+    if (ingredientName.endsWith('?')) {
+        ingredientName = ingredientName.slice(0, -1);
+    }
+
+    if (ingredientType === 'prose') {
+        let proseSection = documentJSON.prose[ingredientName];
+        if (!proseSection) {
+            return;
+        }
+        return <Prose name={ingredientName} content={proseSection} />;
+    } else {
+        const renderer = renderers[ingredientName];
+        if (renderer) {
+            return renderer(ingredientName, documentJSON)
+        }
+    }
+}
+
 function DocumentFromRecipe({ document }) {
   const sections = [];
-
-  // Sanity check
-  if (!document.prose) {
-    throw new Error("Document does not have a .prose");
-  }
-
   const recipe = document.__recipe__;
-  const explicitProse = Object.values(recipe.body)
-    .filter(value => {
-      return (
-        typeof value === "string" &&
-        value.startsWith("prose.") &&
-        value !== "prose.*"
-      );
-    })
-    .map(value => value.replace(/\?$/, "").replace(/^prose\./, ""));
 
-  Object.values(recipe.body).forEach(value => {
-    if (typeof value === "string" && value.startsWith("prose.")) {
-      if (value === "prose.*") {
-        // Gather all that are not mentioned in explicitProse
-        Object.entries(document.prose)
-          .filter(([key, value]) => {
-            // XXX sets?
-            return !explicitProse.includes(key);
-          })
-          .forEach(([key, values]) => {
-            if (key in document.prose) {
-              if (!Array.isArray(values)) {
-                values = [values];
-              }
-              values.forEach((value, i) => {
-                sections.push(
-                  <Prose key={value + i} name={key} content={value} />
-                );
-              });
-            }
-          });
-      } else {
-        const optional = value.endsWith("?");
-        const name = value.replace(/\?$/, "").replace(/^prose\./, "");
-        if (name in document.prose) {
-          // Great! Insert it now.
-          sections.push(
-            <Prose key={value} name={name} content={document.prose[name]} />
-          );
-        } else if (!optional) {
-          throw new Error(
-            `prose section '${name}' is not optional and not present in document.prose`
-          );
-        }
-      }
-    } else if (value === "meta.browser-compatibility") {
-      if (!document.browser_compatibility) {
-        throw new Error("Expecting document to have 'browser_compatibility'");
-      }
-      sections.push(
-        <BrowserCompatibility
-          key={value}
-          content={document.browser_compatibility}
-        />
-      );
-    } else {
-      console.warn(`Not sure what to do with ${JSON.stringify(value)}`);
-    }
-  });
-
-  sections.push(<hr key="metadata-break" />);
-  // Metadata stuff
+  for (let ingredient of Object.values(recipe.body)) {
+      sections.push(RenderIngredient(ingredient, document));
+  }
 
   // The recipe doesn't include to put the contributors so let's add it last
   // if the document has it.
@@ -243,7 +232,9 @@ function DocumentFromRecipe({ document }) {
   return sections;
 }
 
-function Prose({ content }) {
+function Prose({ name, content }) {
+  const headingText = HEADINGS[name];
+  content = `<h2>${headingText}</h2>` + content;
   return <div dangerouslySetInnerHTML={{ __html: content }} />;
 }
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -173,7 +173,7 @@ class Document extends React.Component {
   }
 }
 
-const renderers = {
+const RENDERERS = {
   "interactive-example": InteractiveExample,
   attributes: Attributes,
   examples: Examples,
@@ -202,7 +202,7 @@ function RenderIngredient({ fullName, document }) {
     }
     return <Prose name={ingredientName} content={proseSection} />;
   } else {
-    const Renderer = renderers[ingredientName];
+    const Renderer = RENDERERS[ingredientName];
     if (Renderer) {
       return <Renderer name={ingredientName} document={document} />;
     } else {
@@ -251,7 +251,7 @@ function Prose({ name, content }) {
   const headingText = HEADINGS[name];
   return (
     <>
-      <h2>{headingText}</h2>
+      <h2 id={name}>{headingText}</h2>
       <div dangerouslySetInnerHTML={{ __html: content }} />
     </>
   );

--- a/client/src/ingredients/attributes.js
+++ b/client/src/ingredients/attributes.js
@@ -1,0 +1,41 @@
+import React from "react";
+
+function renderValues(values) {
+    let rendered = '<ul>';
+
+    for (let value of values) {
+        rendered += `<li><code>${value.value}</code>: ${value.description}</li>`;
+    }
+    rendered += '</ul>';
+
+    return rendered;
+}
+
+function renderAttribute(attribute) {
+    let rendered = '<dt>';
+
+    rendered += `<code>${attribute.name}</code>`
+    rendered += '</dt>';
+
+    rendered += '<dd>';
+    rendered += `<strong>${attribute.type}</strong>`;
+    rendered += attribute.description;
+    if (attribute.values) {
+        rendered += renderValues(attribute.values);
+    }
+    rendered += '</dd>';
+
+    return rendered;
+}
+
+export function Attributes(name, documentJSON) {
+  let rendered = '<h2>Attributes</h2>';
+
+  rendered += '<dl>';
+  for (let attribute of documentJSON.attributes) {
+      rendered += renderAttribute(attribute);
+  }
+  rendered += '</dl>';
+
+  return <div dangerouslySetInnerHTML={{ __html: rendered }} />;
+}

--- a/client/src/ingredients/attributes.js
+++ b/client/src/ingredients/attributes.js
@@ -6,7 +6,7 @@ function RenderValues({ values }) {
       {values.map(value => {
         return (
           <li key={value.value}>
-            <code>{value.value}</code>
+            <p><code>{value.value}</code></p>
             <div dangerouslySetInnerHTML={{ __html: value.description }} />
           </li>
         );
@@ -22,7 +22,7 @@ function RenderAttributes({ attributes }) {
         return (
           <React.Fragment key={attribute.name}>
             <dt>
-              <code>{attribute.name}</code>: <i>{attribute.type}</i>
+              <p><code>{attribute.name}</code>: <i>{attribute.type}</i></p>
             </dt>
             <dd>
               {/* XXX a div tag in the middle of a dd tag!

--- a/client/src/ingredients/attributes.js
+++ b/client/src/ingredients/attributes.js
@@ -14,11 +14,10 @@ function renderValues(values) {
 function renderAttribute(attribute) {
     let rendered = '<dt>';
 
-    rendered += `<code>${attribute.name}</code>`
+    rendered += `<code>${attribute.name}</code> : <i>${attribute.type}</i>`
     rendered += '</dt>';
 
     rendered += '<dd>';
-    rendered += `<strong>${attribute.type}</strong>`;
     rendered += attribute.description;
     if (attribute.values) {
         rendered += renderValues(attribute.values);

--- a/client/src/ingredients/attributes.js
+++ b/client/src/ingredients/attributes.js
@@ -6,7 +6,7 @@ function RenderValues({ values }) {
       {values.map(value => {
         return (
           <li key={value.value}>
-            <code>{value.value}</code>:{" "}
+            <code>{value.value}</code>
             <div dangerouslySetInnerHTML={{ __html: value.description }} />
           </li>
         );

--- a/client/src/ingredients/examples.js
+++ b/client/src/ingredients/examples.js
@@ -1,10 +1,13 @@
 import React from "react";
 
+function slugifyTitle(title) {
+    return title.toLowerCase().replace(/ /gi, "_")
+}
+
 function RenderSources({ sources }) {
   return (
     <>
       {sources.html && <h4>HTML</h4>}
-      {/* <code> inside a <pre>?? Is that necessary? */}
       {sources.html && (
         <pre>
           <code>{sources.html}</code>
@@ -43,15 +46,14 @@ function RenderLiveSample({ example }) {
     <>
       <h4>Result</h4>
       <iframe
-        className="live-sample-frame sample-code-frame"
+        className="live-sample-frame"
         srcDoc={srcdoc}
         title={example.description.title}
-        id="frame_Live_example"
+        id={slugifyTitle(example.description.title)}
         width={example.description.width}
         height={example.description.height}
         frameBorder={0}
       >
-        >
       </iframe>
     </>
   );
@@ -70,7 +72,8 @@ function RenderExample({ example }) {
 
       <RenderSources sources={example.sources} />
 
-      {/* XXX this is an odd condition */}
+      {/* At the moment the author implicitly signals that an example is live
+        by including width and height values for the iframe */}
       {example.description.width && <RenderLiveSample example={example} />}
     </>
   );

--- a/client/src/ingredients/examples.js
+++ b/client/src/ingredients/examples.js
@@ -1,0 +1,75 @@
+import React from "react";
+
+const escape = require('escape-html');
+
+function renderSources(example) {
+    let rendered = '';
+
+    if (example.sources.html) {
+        rendered += '<h4>HTML</h4>';
+        rendered += `<pre><code>${escape(example.sources.html)}</code></pre>`;
+    }
+
+    if (example.sources.css) {
+        rendered += '<h4>CSS</h4>';
+        rendered += `<pre><code>${escape(example.sources.css)}</code></pre>`;
+    }
+
+    if (example.sources.js) {
+        rendered += '<h4>JavaScript</h4>';
+        rendered += `<pre><code>${escape(example.sources.js)}</code></pre>`;
+    }
+
+    return rendered;
+}
+
+function renderLiveSample(example) {
+
+    const srcdoc =
+`<html>
+  <head>
+      <meta charset="utf-8">
+      <style type="text/css">${example.sources.css}</style>
+      <title>${example.description.title}</title>
+  </head>
+  <body>${example.sources.html}
+      <script>${example.sources.js}</script>
+  </body>
+</html>`;
+
+    const iframe =
+`<iframe class="live-sample-frame sample-code-frame" id="frame_Live_example"
+    srcdoc="${escape(srcdoc)}"
+    width="${example.description.width}px"
+    height="${example.description.height}px"
+    frameborder="0">
+</iframe>`;
+
+    return `<h4>Result</h4>${iframe}`;
+}
+
+function renderExample(example) {
+    let rendered = '';
+
+    if (example.description.title) {
+        rendered += `<h3>${escape(example.description.title)}</h3>`;
+        rendered += example.description.content;
+    }
+
+    rendered += renderSources(example);
+
+    if (example.description.width) {
+        rendered += renderLiveSample(example);
+    }
+
+    return rendered;
+}
+
+
+export function Examples(name, documentJSON) {
+  let rendered = '<h2>Examples</h2>';
+  for (let example of documentJSON.examples) {
+      rendered += renderExample(example);
+  }
+  return <div dangerouslySetInnerHTML={{ __html: rendered }} />;
+}

--- a/client/src/ingredients/interactive-example.js
+++ b/client/src/ingredients/interactive-example.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+export function InteractiveExample(name, documentJSON) {
+  let rendered = `<div><iframe class="interactive tabbed-standard" frameborder="0" height="450" src="${documentJSON.interactive_example_url}" width="100%"></iframe></div>`;
+
+  return <div dangerouslySetInnerHTML={{ __html: rendered }} />;
+}

--- a/client/src/ingredients/interactive-example.js
+++ b/client/src/ingredients/interactive-example.js
@@ -5,7 +5,7 @@ export function InteractiveExample({ document }) {
     <div>
       <iframe
         title={`Interactive example for ${document.title}`}
-        className="interactive tabbed-standard"
+        className="interactive-example"
         frameBorder={0}
         height={450}
         src={document.interactive_example_url}


### PR DESCRIPTION
Thanks for the updates today, it made it much less painful to get things running.

I know essentially nothing about React, so I'm probably doing some awful things here, but I wanted to get the code from https://github.com/mdn/stumptown-experiment/pull/33 running in your environment, and that's what this PR does.

Specifically it does a couple of things:

* I replaced a lot of `DocumentFromRecipe`: partly because I think the way it was doing prose sections was wrong (you don't just stick together all the prose sections, you have to interleave them with other sections like interactive examples), and partly because I wanted a way to have a bit of separation between this function and the renderers, so it's fairly simple to add new renderers. And I didn't want them all in the same source file.

* I ported the bits of https://github.com/mdn/stumptown-experiment/pull/33. I put the individual renderers as separate modules in an "ingredients" directory, which isn't a very good name.

I don't particularly care about any of the code as long as it's modular, so people can implement renderers without stepping on each others' toes.

But, this works (for me anyway) to give us a page that has:
* all prose sections in the right place (except prose.*, which would be easy enough to add)
* interactive example
* attributes
* examples, including live samples

And I'm happy with how much this looks like an MDN page!

There are a couple of obvious bugs:

* the attributes are not always represented correctly in the JSON (the "Type" is mistakenly absorbed into the attribute description sometimes. This needs to be fixed in the JSON builder (and I know what the fix is).

* the prose sections sometimes have 2 headings: that's because the prose sections in the JSON sometimes contains the heading, and the renderer always adds a section heading. We're discussing this in https://github.com/mdn/stumptown-experiment/issues/19, and I think the upshot will be that the prose section in the JSON will contain the heading as a separate property from the content, and the content will never contain it. Like:

```
short_description: {
    heading: "Short description",
    content: "<p>Something something</p>"
}
```