### PR TITLE
Upgrade stumptown

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -83,12 +83,19 @@ function buildHtmlAndJson({ filePath, output, buildHtml }) {
     if (!match) {
       throw new Error(`Urecognized URL pattern ${uri}`);
     }
-    rendered = render(
-      <Router context={{}} location={uri}>
-        <App {...options} />
-      </Router>,
-      options
-    );
+    try {
+      rendered = render(
+        <Router context={{}} location={uri}>
+          <App {...options} />
+        </Router>,
+        options
+      );
+    } catch (ex) {
+      console.error(`Rendering HTML failed!
+      uri=${uri}
+      filePath=${filePath}`);
+      throw ex;
+    }
   }
 
   fs.mkdirSync(destination, { recursive: true });


### PR DESCRIPTION
I just wanted to try out the [latest stumptown](https://github.com/mdn/stumptown-experiment/commit/fdd943e96307b64ff6b32cbe98133f33012aea86). Seems to work. 

Generating the static HTML for *all* pages is breaking on something else now. So I snook in a slight improvement to that by catching the error, `console.error` some important details, then rethrow the error. Now when you run `make deployment-build` you get this:

```
Rendering HTML failed!
      uri=/docs/Web/HTML/Element/abbr
      filePath=../stumptown/packaged/html/elements/abbr.json

/Users/peterbe/dev/MOZILLA/MDN/mdn2/cli/dist/webpack:/.ent/src/ingredients/attributes.js:21
      {attributes.map(attribute => {
                  ^
TypeError: Cannot read property 'map' of null
    at map (/Users/peterbe/dev/MOZILLA/MDN/mdn2/cli/dist/webpack:/.ent/src/ingredients/attributes.js:21:19)
    at processChild (/Users/peterbe/dev/MOZILLA/MDN/mdn2/cli/node_modules/react-dom/cjs/react-dom-server.node.development.js:2888:14)
    at resolve (/Users/peterbe/dev/MOZILLA/MDN/mdn2/cli/node_modules/react-dom/cjs/react-dom-server.node.development.js:2812:5)
    at ReactDOMServerRenderer.render (/Users/peterbe/dev/MOZILLA/MDN/mdn2/cli/node_modules/react-dom/cjs/react-dom-server.node.development.js:3202:22)
    at ReactDOMServerRenderer.read (/Users/peterbe/dev/MOZILLA/MDN/mdn2/cli/node_modules/react-dom/cjs/react-dom-server.node.development.js:3161:29)
    at renderToString (/Users/peterbe/dev/MOZILLA/MDN/mdn2/cli/node_modules/react-dom/cjs/react-dom-server.node.development.js:3646:27)
    at ./render.js.__webpack_exports__.default (/Users/peterbe/dev/MOZILLA/MDN/mdn2/cli/dist/webpack:/render.js:33:34)
    at buildHtmlAndJson (/Users/peterbe/dev/MOZILLA/MDN/mdn2/cli/dist/webpack:/index.js:87:24)
    at buildHtmlAndJson (/Users/peterbe/dev/MOZILLA/MDN/mdn2/cli/dist/webpack:/index.js:190:5)
    at FSReqCallback.oncomplete (fs.js:137:23)
error Command failed with exit code 1.
```

Note the first 3 lines. What do you think?