### PR TITLE
Style live sample output iframe

### DIFF
--- a/client/src/mdn.scss
+++ b/client/src/mdn.scss
@@ -1,3 +1,7 @@
+* {
+    box-sizing: border-box;
+}
+
 div.page-title {
   background-color: #f5f9fa;
   padding: 10px;
@@ -42,11 +46,18 @@ div.content {
     max-width: 70rem;
   }
 
+  .live-sample-frame {
+    border: 1px solid #3d7e9a;
+    border-width: 1px 1px 1px 5px;
+    padding: 10px;
+  }
+
   p,
   dl,
   ul,
   ol,
-  pre {
+  pre,
+  .live-sample-frame {
     max-width: 42rem;
   }
 }


### PR DESCRIPTION
This PR adds a border and width setting to the output iframe used for live samples. Without it, the video examples look OK but other examples look terrible:

<img width="718" alt="Screen Shot 2019-06-05 at 2 49 43 PM" src="https://user-images.githubusercontent.com/432915/58992887-d768d680-87a0-11e9-8049-19fcaea75fd2.png">

******

<img width="730" alt="Screen Shot 2019-06-05 at 2 50 24 PM" src="https://user-images.githubusercontent.com/432915/58992897-dfc11180-87a0-11e9-8f13-8f01cc996991.png">
