### PR TITLE
Remove the renderer's dependency on recipes.

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -35,14 +35,6 @@ function mapToURI({ document }) {
   return url.parse(document.mdn_url).pathname;
 }
 
-function getRecipe({ document }) {
-  // XXX this needs to get smarter!
-  const recipe = yaml.safeLoad(
-    fs.readFileSync("../stumptown/recipes/html-element.yaml", "utf8")
-  );
-  return recipe;
-}
-
 function buildHtmlAndJson({ filePath, output, buildHtml }) {
   const data = fs.readFileSync(filePath, "utf8");
   // const buildHash = crypto
@@ -57,7 +49,6 @@ function buildHtmlAndJson({ filePath, output, buildHtml }) {
     // XXX this is weird
     document: jsonData.html.elements[baseNameSans]
   };
-  options.document.__recipe__ = getRecipe(jsonData);
 
   const uri = mapToURI({ filePath, document: options.document });
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -156,7 +156,7 @@ class Document extends React.Component {
         <div className="main">
           <div className="sidebar">SIDE BAR</div>
           <div className="content">
-            <DocumentFromRecipe document={document} />
+            <RenderHTMLElementDocument document={document} />
           </div>
         </div>
       </div>
@@ -164,71 +164,21 @@ class Document extends React.Component {
   }
 }
 
-const RENDERERS = {
-  "interactive_example": InteractiveExample,
-  attributes: Attributes,
-  examples: Examples,
-  "browser_compatibility": BrowserCompatibility
-};
+function RenderHTMLElementDocument({ document }) {
+  let sections = [];
 
-function RenderIngredient({ fullName, document }) {
-  let parts = fullName.split(".");
-  if (parts.length !== 2) {
-    throw new Error(
-      `ingredient name '${fullName}' should be 2 strings separated by a period`
-    );
-  }
+  sections.push(<Prose section={document.prose.short_description} />);
+  sections.push(<InteractiveExample document={document} />);
+  sections.push(<Prose section={document.prose.overview} />);
+  sections.push(<Attributes document={document} />);
+  sections.push(<ProseWithHeading section={document.prose.usage_notes} />);
+  sections.push(<ProseWithHeading section={document.prose.accessibility_concerns} />);
+  sections.push(<Examples document={document} />);
+  sections.push(<BrowserCompatibility document={document} />);
+  sections.push(<ProseWithHeading section={document.prose.see_also} />);
 
-  let ingredientType = parts[0];
-  let ingredientName = parts[1];
-  // we're not checking for missing mandatory sections here (yet?)
-  if (ingredientName.endsWith("?")) {
-    ingredientName = ingredientName.slice(0, -1);
-  }
+  sections = sections.filter(s => !!s);
 
-  if (ingredientType === "prose") {
-    let proseSection = document.prose[ingredientName];
-    if (!proseSection) {
-      return null;
-    }
-    return <Prose id={ingredientName} section={proseSection} />;
-  } else {
-    const Renderer = RENDERERS[ingredientName];
-    if (Renderer) {
-      return <Renderer name={ingredientName} document={document} />;
-    } else {
-      throw new Error(`No available renderer for '${ingredientName}`);
-    }
-  }
-}
-
-function DocumentFromRecipe({ document }) {
-  const sections = [];
-  const recipe = document.__recipe__;
-
-  const ingredientSections = Object.values(recipe.body).map(ingredient => {
-    // one of the ingredients is not a string, and we don't handle it yet
-    if (typeof ingredient !== "string") {
-      console.warn(
-        `Not sure how to deal with non-string ingredients '${JSON.stringify(
-          ingredient
-        )}'`
-      );
-      return null;
-    }
-    return (
-      <RenderIngredient
-        key={ingredient}
-        fullName={ingredient}
-        document={document}
-      />
-    );
-  });
-
-  sections.push(...ingredientSections);
-
-  // The recipe doesn't include to put the contributors so let's add it last
-  // if the document has it.
   if (document.contributors) {
     sections.push(
       <Contributors key="contributors" contributors={document.contributors} />
@@ -238,7 +188,18 @@ function DocumentFromRecipe({ document }) {
   return sections;
 }
 
-function Prose({ id, section }) {
+function Prose({ section }) {
+  if (!section) {
+    return null;
+  }
+  return (
+    <>
+      <div dangerouslySetInnerHTML={{ __html: section.content }} />
+    </>
+  );
+}
+
+function ProseWithHeading({ id, section }) {
   return (
     <>
       <h2 id={id}>{section.title}</h2>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -157,6 +157,8 @@ class Document extends React.Component {
           <div className="sidebar">SIDE BAR</div>
           <div className="content">
             <RenderHTMLElementDocument document={document} />
+            <hr/>
+            {document.contributors && <Contributors contributors={document.contributors}/>}
           </div>
         </div>
       </div>
@@ -167,23 +169,15 @@ class Document extends React.Component {
 function RenderHTMLElementDocument({ document }) {
   let sections = [];
 
-  sections.push(<Prose section={document.prose.short_description} />);
-  sections.push(<InteractiveExample document={document} />);
-  sections.push(<Prose section={document.prose.overview} />);
-  sections.push(<Attributes document={document} />);
-  sections.push(<ProseWithHeading section={document.prose.usage_notes} />);
-  sections.push(<ProseWithHeading section={document.prose.accessibility_concerns} />);
-  sections.push(<Examples document={document} />);
-  sections.push(<BrowserCompatibility document={document} />);
-  sections.push(<ProseWithHeading section={document.prose.see_also} />);
-
-  sections = sections.filter(s => !!s);
-
-  if (document.contributors) {
-    sections.push(
-      <Contributors key="contributors" contributors={document.contributors} />
-    );
-  }
+  sections.push(<Prose key="short_description" section={document.prose.short_description} />);
+  sections.push(<InteractiveExample key="interactive_example" document={document} />);
+  sections.push(<Prose key="overview" section={document.prose.overview} />);
+  sections.push(<Attributes key="attributes" document={document} />);
+  sections.push(<ProseWithHeading key="usage_notes" section={document.prose.usage_notes} />);
+  sections.push(<ProseWithHeading key="accessibility_concerns" section={document.prose.accessibility_concerns} />);
+  sections.push(<Examples key="examples" document={document} />);
+  sections.push(<BrowserCompatibility key="browser_compatibility" document={document} />);
+  sections.push(<ProseWithHeading key="see_also" section={document.prose.see_also} />);
 
   return sections;
 }
@@ -193,9 +187,7 @@ function Prose({ section }) {
     return null;
   }
   return (
-    <>
-      <div dangerouslySetInnerHTML={{ __html: section.content }} />
-    </>
+    <div dangerouslySetInnerHTML={{ __html: section.content }} />
   );
 }
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -200,6 +200,9 @@ function Prose({ section }) {
 }
 
 function ProseWithHeading({ id, section }) {
+  if (!section) {
+    return null;
+  }
   return (
     <>
       <h2 id={id}>{section.title}</h2>


### PR DESCRIPTION
For https://github.com/mdn/sprints/issues/1638, I need to be able to suppress headings for short descriptions and overview, and this seems to make us confront the split between recipes in stumptown and the way MDN wants to render pages.

In this PR I'm doing this by hardcoding the set of things to include in the renderer itself. I think you suggested this in conversation yesterday, @peterbe , and it seems somewhat in line with especially @ddbeck 's https://github.com/mdn/stumptown-experiment/issues/48#issuecomment-498992233.

I like this better: it's smaller, simpler, more explicit. Although we would want a way some time to represent the fact that HTML elements are only one of the page types we know how to render.

What do you think?