### PR TITLE
more travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ matrix:
       cache: yarn
       script:
         - ./scripts/ci-client.sh
-    - end-to-end:
+    - name: end-to-end
       cache: yarn
       script:
         - make build-content
         # Commented out June 6 because at the moment 'make deployment-build' will fail
         # - make deployment-build
-    - yarn-audit:
+    - name: yarn-audit
       cache: yarn
       script:
         - make yarn-audit-all

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+
+# Ideally nobody should push PRs to the "origin" repo.
+# Remove this once the repo is moved to the 'mdn' org.
+branches:
+  only:
+    - master
+
 language: node_js
 node_js: stable
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ branches:
 language: node_js
 node_js: stable
 
+# Because https://github.com/travis-ci/travis-ci/issues/9445
+before_install:
+  - npm install -g yarn
+  - yarn --version
+
 matrix:
   include:
     - name: client

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ node_js: stable
 matrix:
   include:
     - name: client
+      cache: yarn
       script:
         - set -e
         - cd client && yarn run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,13 @@ matrix:
       cache: yarn
       script:
         - ./scripts/ci-client.sh
+    - end-to-end:
+      cache: yarn
+      script:
+        - make build-content
+        # Commented out June 6 because at the moment 'make deployment-build' will fail
+        # - make deployment-build
+    - yarn-audit:
+      cache: yarn
+      script:
+        - make yarn-audit-all

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,4 @@ matrix:
     - name: client
       cache: yarn
       script:
-        - set -e
-        - cd client && yarn run test
-        - cd client && yarn run build
+        - ./scripts/ci-client.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,19 @@ branches:
 language: node_js
 node_js: stable
 
+cache:
+  yarn: true
+  directories:
+    - client/node_modules
+    - server/node_modules
+    - cli/node_modules
+
 # Because https://github.com/travis-ci/travis-ci/issues/9445
 before_install:
   - npm install -g yarn
   - yarn --version
+  # All nodes of the matrix will
+  - make install
 
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mdn2
 
+[![Build Status](https://travis-ci.org/peterbe/mdn2.svg?branch=master)](https://travis-ci.org/peterbe/mdn2)
+
 **THIS IS HIGHLY EXPERIMENTAL AND LIKELY TO CHANGE DRASTICALLY**
 
 ## Overview

--- a/scripts/ci-client.sh
+++ b/scripts/ci-client.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ex
+
+# If you run this locally, the jest test runner will
+# start in interactive mode. To make it like in CI
+# execute this script like `CI=true ./scripts/ci-client.sh
+
+cd client
+yarn
+yarn run test
+yarn run build


### PR DESCRIPTION
You can't argue with the results :)

First of all, we're not done with Travis. We'd want to run a linter across all apps (client, server, cli). We also want to run the `make deployment-build` which produces fully working `.html` which we should test that they work and can be opened with `curl` or something. 

I'm not sure I'm doing the matrix stuff right. Would love some feedback here. There's a `before_install` portion *before* the matrix but I think it runs that once per every step in the matix. I'd rather just do the stuff, currently in `before_install` once BEFORE all the matrix sections. 

I'm happy to land this early and iterate. I just want to get the wheels rolling. 

Also, if we [dockerize everything](https://github.com/peterbe/mdn2/issues/23) all of these Travis DSL tricks will become moot. 