### PR TITLE
be lenient with example titles' presence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,7 @@ matrix:
       cache: yarn
       script:
         - make build-content
-        # Commented out June 6 because at the moment 'make deployment-build' will fail
-        # - make deployment-build
+        - make deployment-build
     - name: yarn-audit
       cache: yarn
       script:

--- a/client/src/ingredients/examples.js
+++ b/client/src/ingredients/examples.js
@@ -48,12 +48,7 @@ function RenderLiveSample({ example }) {
       <iframe
         className="live-sample-frame"
         srcDoc={srcdoc}
-        title={example.description.title || null}
-        id={
-          example.description.title
-            ? slugifyTitle(example.description.title)
-            : null
-        }
+        title={example.description.title || "Live sample"}
         width={example.description.width}
         height={example.description.height}
         frameBorder={0}
@@ -67,7 +62,7 @@ function RenderExample({ example }) {
     <>
       {example.description.title && <h3>{example.description.title}</h3>}
 
-      {example.description.title && (
+      {example.description.content && (
         <div
           dangerouslySetInnerHTML={{ __html: example.description.content }}
         />

--- a/client/src/ingredients/examples.js
+++ b/client/src/ingredients/examples.js
@@ -82,7 +82,7 @@ export function Examples({ document }) {
     <>
       <h2>Examples</h2>
       {document.examples.map((example, i) => (
-        <RenderExample key={example.description.title + i} example={example} />
+        <RenderExample key={i} example={example} />
       ))}
     </>
   );

--- a/client/src/ingredients/examples.js
+++ b/client/src/ingredients/examples.js
@@ -1,9 +1,5 @@
 import React from "react";
 
-function slugifyTitle(title) {
-  return title.toLowerCase().replace(/ /gi, "_");
-}
-
 function RenderSources({ sources }) {
   return (
     <>

--- a/client/src/ingredients/examples.js
+++ b/client/src/ingredients/examples.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 function slugifyTitle(title) {
-    return title.toLowerCase().replace(/ /gi, "_")
+  return title.toLowerCase().replace(/ /gi, "_");
 }
 
 function RenderSources({ sources }) {
@@ -48,13 +48,16 @@ function RenderLiveSample({ example }) {
       <iframe
         className="live-sample-frame"
         srcDoc={srcdoc}
-        title={example.description.title}
-        id={slugifyTitle(example.description.title)}
+        title={example.description.title || null}
+        id={
+          example.description.title
+            ? slugifyTitle(example.description.title)
+            : null
+        }
         width={example.description.width}
         height={example.description.height}
         frameBorder={0}
-      >
-      </iframe>
+      />
     </>
   );
 }


### PR DESCRIPTION
This isn't very deeply thought out but I think it might help a little. 
With this change, you can render out .html files for every single "html" element. Nifty!

As of this change http://localhost:3000/docs/Web/HTML/Element/aside now works and `make deployment-build` also works. 